### PR TITLE
Update version to 7049

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ Run the rest of the commands in this interactive shell.
 python3 -m pip install -r requirements.txt
 ```
 
+You may need to setup a virtual environment on Ubuntu systems to use PIP without breaking system packages.
+
+```
+sudo apt install python3-venv
+python3 -m venv .
+source bin/activate
+```
+
+These commands install venv and set it up for the current directory.
+
 3. Get Google Depot Tools:
 
 ```

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Project to compile PDFium library to multiple platforms.
 
 We are only going to use the wasm binaries for our purposes. You can either utilize a Ubuntu **20.04/22.04/24.04** instance or run a docker container instance. _Note that the minor ver .04 is important here as compiling it on a different minor .10 will not work._ Alternatively use the docker container to setup the compiling environment beforehand.
 
+Note: It seems that only x86-64 architectures are supported, if running an ARM processor, using the docker method to emulate will work fine and reasonably fast.
+
 NOTE: STEPS 1-3 IS ONLY REQUIRED TO BE RAN ONCE. OTHER STEPS MUST BE RAN EVERY TIME FOR A BUILD.
 
 1. Get the source, make sure that it is commit(s) ahead of upstream with `addFunction`, `removeFunction`, and `-sALLOW_TABLE_GROWTH` part of the wasm compilation exports.
@@ -63,13 +65,18 @@ Run the rest of the commands in this interactive shell.
 python3 -m pip install -r requirements.txt
 ```
 
-You may need to setup a virtual environment on Ubuntu systems to use PIP without breaking system packages.
+<details>
+<br>
+<summary>You may need to setup a virtual environment on Ubuntu systems to use PIP without breaking system packages.</summary>
 
 ```
 sudo apt install python3-venv
 python3 -m venv .
 source bin/activate
 ```
+
+<br>
+</details>
 
 These commands install venv and set it up for the current directory.
 
@@ -83,30 +90,64 @@ export PATH=$PATH:$PWD/build/depot-tools
 From here forth only these steps need to be ran for compilation.
 
 4. Get Emscripten SDK:
-   `python3 make.py build-emsdk`
 
-5. Execute EMSDK environment file "emsdk_env" according to your system. For us this should be `/emsdk/emsdk_env.sh`
+   ```
+   python3 make.py build-emsdk
+   ```
+
+5. The command to execute the EMSDK enviroment file may fail, you may need to manually set it up with: (or something simliar). Not exactly sure why it doesn't run successfully from the script.
+
+   ```
+   source build/emsdk/emsdk_env.sh
+   ```
 
 6. Get PDFium:
-   `python3 make.py build-pdfium-wasm`
+
+   ```
+   python3 make.py build-pdfium-wasm
+   ```
 
 7. Patch:
-   `python3 make.py patch-wasm`
+
+   ```
+   python3 make.py patch-wasm
+   ```
 
 8. PDFium Linux dependencies
-   `./build/wasm32/pdfium/build/install-build-deps.sh`
+
+   ```
+   ./build/wasm32/pdfium/build/install-build-deps.sh
+   ```
 
 9. Compile:
-   `python3 make.py build-wasm`
+
+   ```
+   python3 make.py build-wasm
+   ```
+
+   You may get an error asking you to initialize depot_tools:
+
+   ```
+   export DEPOT_TOOLS_UPDATE=1
+   update_depot_tools
+   ```
 
 10. Install libraries:
-    `python3 make.py install-wasm`
+
+    ```
+    python3 make.py install-wasm
+    ```
 
 11. Test:
-    `python3 make.py test-wasm`
+
+    ```
+    python3 make.py test-wasm
+    ```
 
 12. Generate javascript libraries:
-    `python3 make.py generate-wasm`
+    ```
+    python3 make.py generate-wasm
+    ```
 
 At this point you should be able to find `pdfium.js` and `pdfium.wasm` inside `./build/wasm32/wasm/release/node`, those replace the current `pdfium.js` and `pdfium.wasm` files in our projects.
 

--- a/docker/wasm/Dockerfile
+++ b/docker/wasm/Dockerfile
@@ -38,7 +38,7 @@ RUN mkdir /build
 WORKDIR /build
 RUN gclient config --custom-var checkout_configuration=minimal --unmanaged https://pdfium.googlesource.com/pdfium.git
 RUN echo "target_os = [ 'wasm' ]" >> .gclient
-RUN gclient sync -r origin/chromium/6694 --no-history --shallow
+RUN gclient sync -r origin/chromium/7049 --no-history --shallow
 
 # pdfium reset and clean directories
 RUN git -C /build/pdfium reset --hard
@@ -60,11 +60,11 @@ RUN git status
 # system dependencies
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
-RUN apt-get install -o APT::Immediate-Configure=false -f apt \
+RUN apt-get -y install -o APT::Immediate-Configure=false -f apt \
     && apt-get -f install \
     && dpkg --configure -a \
-    && apt-get -y dist-upgrade \
-    && echo n | ./build/install-build-deps.sh \
+    && apt-get -f dist-upgrade \
+    && echo y | ./build/install-build-deps.sh \
     && rm -rf /build
 
 # ninja
@@ -78,8 +78,8 @@ RUN pip3 install setuptools docopt pygemstones
 RUN mkdir /emsdk
 WORKDIR /emsdk
 RUN git clone https://github.com/emscripten-core/emsdk.git .
-RUN ./emsdk install 3.1.64
-RUN ./emsdk activate 3.1.64
+RUN ./emsdk install 3.1.74
+RUN ./emsdk activate 3.1.74
 ENV PATH="${PATH}:/emsdk:/emsdk/upstream/emscripten"
 
 # cache system libraries
@@ -87,7 +87,7 @@ RUN bash -c 'echo "int main() { return 0; }" > /tmp/main.cc'
 RUN bash -c 'source /emsdk/emsdk_env.sh && em++ -s USE_ZLIB=1 -s USE_LIBJPEG=1 -s USE_PTHREADS=1 -s ASSERTIONS=1 -o /tmp/main.html /tmp/main.cc'
 
 # nodejs and npm
-RUN curl -sL https://deb.nodesource.com/setup_18.x | sudo -E bash -
+RUN curl -sL https://deb.nodesource.com/setup_20.x | sudo -E bash -
 RUN apt-get install -y nodejs
 RUN npm install -g npm@latest
 

--- a/modules/config.py
+++ b/modules/config.py
@@ -4,7 +4,7 @@ task = ""
 
 # pdfium
 pdfium_git_branch = "chromium/7049"
-# ^ ref: https://pdfium.googlesource.com/pdfium/+/refs/heads/chromium/7188
+# ^ ref: https://pdfium.googlesource.com/pdfium/+/refs/heads/chromium/7049
 # OBS 1: don't forget change in android docker file (docker/android/Dockerfile)
 # OBS 2: don't forget change in wasm docker file (docker/wasm/Dockerfile)
 

--- a/modules/config.py
+++ b/modules/config.py
@@ -3,13 +3,13 @@ debug = False
 task = ""
 
 # pdfium
-pdfium_git_branch = "chromium/6694"
-# ^ ref: https://pdfium.googlesource.com/pdfium/+/refs/heads/chromium/6694
+pdfium_git_branch = "chromium/7049"
+# ^ ref: https://pdfium.googlesource.com/pdfium/+/refs/heads/chromium/7188
 # OBS 1: don't forget change in android docker file (docker/android/Dockerfile)
 # OBS 2: don't forget change in wasm docker file (docker/wasm/Dockerfile)
 
 # emsdk
-emsdk_version = "3.1.64"
+emsdk_version = "3.1.74"
 # OBS 1: don't forget change in wasm docker file (docker/wasm/Dockerfile)
 
 # macos


### PR DESCRIPTION
This was the latest release I could get working without having to deal with some major problems. Updated the README a bit for build instructions, ideally, it should contain all the commands and info needed for anyone to successfully make the build.

For testing, just go through to README instructions and check that all the instructions are clear and the process works without any errors.